### PR TITLE
Add wildcard parsing to hostname filter

### DIFF
--- a/hostname_filter.go
+++ b/hostname_filter.go
@@ -1,6 +1,8 @@
 package cproxy
 
-import "net/http"
+import (
+	"net/http"
+)
 
 type HostnameFilter struct {
 	authorized []string
@@ -14,7 +16,12 @@ func (this HostnameFilter) IsAuthorized(request *http.Request) bool {
 	host := request.URL.Host
 
 	for _, authorized := range this.authorized {
-		if authorized == host {
+		if authorized[:2] == "*." {
+			have, want := len(host), len(authorized) - 1
+			if have > want && authorized[1:] == host[len(host)-want:] {
+				return true
+			}
+		} else if authorized == host {
 			return true
 		}
 	}

--- a/hostname_filter_test.go
+++ b/hostname_filter_test.go
@@ -19,7 +19,7 @@ type HostnameFilterFixture struct {
 }
 
 func (this *HostnameFilterFixture) Setup() {
-	this.filter = NewHostnameFilter([]string{"domain:1234", "sub.domain2:5678"})
+	this.filter = NewHostnameFilter([]string{"domain:1234", "sub.domain2:5678", "*.xyz.domain3:9012"})
 }
 
 func (this *HostnameFilterFixture) TestDenied() {
@@ -30,6 +30,8 @@ func (this *HostnameFilterFixture) TestDenied() {
 	this.assertUnauthorized("whatever.domain2:5678")
 	this.assertUnauthorized("whatever.sub.domain2:5678")
 	this.assertUnauthorized("somedomain:1234") // must match exactly
+	this.assertUnauthorized("domain3:1234")
+	this.assertUnauthorized("xyz.domain3:9012")
 }
 
 func (this *HostnameFilterFixture) assertUnauthorized(domain string) {
@@ -40,6 +42,8 @@ func (this *HostnameFilterFixture) assertUnauthorized(domain string) {
 func (this *HostnameFilterFixture) TestAuthorized() {
 	this.assertAuthorized("domain:1234")
 	this.assertAuthorized("sub.domain2:5678")
+	this.assertAuthorized("a.xyz.domain3:9012")
+	this.assertAuthorized("b.xyz.domain3:9012")
 }
 
 func (this *HostnameFilterFixture) assertAuthorized(domain string) {


### PR DESCRIPTION
This is a simple change to allow the hostname filter to accept strings that start with `*.` to allow wildcard subdomains.  Its suitable for me, but also open to interpretation as to the correctness of the implementation, given that `*.foo.com` will match `x.y.foo.com`, and also `*` is a valid subdomain which could not singled out anymore.  There may also be a performance reason to avoid the extra branching.

Given these caveats, you may or may not want to accept this change to the library.  I figured I'd submit the PR and let you decide.  Thanks for the library, it looks like exactly what I need right now.