### PR TITLE
Add support for Filter.IsAuthorized() to modify the response

### DIFF
--- a/default_filter.go
+++ b/default_filter.go
@@ -8,6 +8,6 @@ func NewFilter() *DefaultFilter {
 	return &DefaultFilter{}
 }
 
-func (it *DefaultFilter) IsAuthorized(request *http.Request) bool {
+func (it *DefaultFilter) IsAuthorized(request *http.Request, response http.ResponseWriter) bool {
 	return true
 }

--- a/default_filter_test.go
+++ b/default_filter_test.go
@@ -19,6 +19,7 @@ type FilterFixture struct {
 func (it *FilterFixture) TestAllowEverything() {
 	filter := NewFilter()
 
-	it.So(filter.IsAuthorized(nil), should.BeTrue)
-	it.So(filter.IsAuthorized(httptest.NewRequest("GET", "/", nil)), should.BeTrue)
+	it.So(filter.IsAuthorized(nil, nil), should.BeTrue)
+	it.So(filter.IsAuthorized(httptest.NewRequest("GET", "/", nil), nil), should.BeTrue)
+	it.So(filter.IsAuthorized(httptest.NewRequest("GET", "/", nil), httptest.NewRecorder()), should.BeTrue)
 }

--- a/default_handler.go
+++ b/default_handler.go
@@ -25,7 +25,7 @@ func (it *DefaultHandler) ServeHTTP(response http.ResponseWriter, request *http.
 		it.meter.Measure(MeasurementBadMethod)
 		writeResponseStatus(response, http.StatusMethodNotAllowed)
 
-	} else if !it.filter.IsAuthorized(request) {
+	} else if !it.filter.IsAuthorized(request, response) {
 		it.meter.Measure(MeasurementUnauthorizedRequest)
 		writeResponseStatus(response, http.StatusUnauthorized)
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,7 +8,7 @@ import (
 
 type (
 	Filter interface {
-		IsAuthorized(*http.Request) bool
+		IsAuthorized(*http.Request, http.ResponseWriter) bool
 	}
 
 	ClientConnector interface {


### PR DESCRIPTION
I'm trying to implement a proxy that allows the user to bypass a blocked URL if they present the proper password using a basic auth prompt in their browser.

To do that, I need to be able to set the `WWW-Authenticate` header on the response and return `false` from `IsAuthorized()`.

This PR allows the `http.ResponseWriter` to be passed to the `IsAuthorized()` function of the `Filter` interface so that headers can be added to the response to enable the desired behavior described above.